### PR TITLE
Fix issue where the export CLI is not returning a 0 exit-code for failures. Closes #72

### DIFF
--- a/templates/main.go.tmpl
+++ b/templates/main.go.tmpl
@@ -241,6 +241,8 @@ func executeQuery(tableName string, conectionName string, columns []string, qual
 		response, err := stream.Recv()
 		if err != nil {
 			fmt.Printf("[ERROR] Error receiving data from the channel: %v", err)
+			// return a non-zero exit code
+			os.Exit(1)
 			break
 		}
 		if response == nil {


### PR DESCRIPTION
```
➜  steampipe_export_aws aws_account --config 'profile="hawkeye"'
[ERROR] 1720001800681: getCallerIdentityUncached: status=failed connection_name=aws api_error="operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid."
[ERROR] 1720001800681: getCommonColumnsUncached: status=failed connection_name=aws region=global error="operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid."
[ERROR] 1720001800681: aws_account.listAccountAlias: common_data_error="operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid."
[WARN]  1720001800681: doList callHydrateWithRetries (aws-1720001800681) returned err operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid.
[WARN]  1720001800681: QueryData StreamError operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid. (aws-1720001800681)
[WARN]  1720001800681: streamRows execution has failed: aws-1720001800681 - calling queryCache.AbortSet (aws: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid.)
[WARN]  1720001800681: queryData.streamRows returned error: aws: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid.
[WARN]  1720001800681: executeForConnection aws returned error aws: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid., writing to CHAN
[WARN]  1720001800681: error channel received aws: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid.
[ERROR] Error receiving data from the channel: aws: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: f8961301-44a4-4cfc-beac-25455987e31d, api error InvalidClientTokenId: The security token included in the request is invalid.
➜  echo $?
1
```